### PR TITLE
Fix VM ID parsing in `associate_address()`

### DIFF
--- a/src/cloud/ec2/lib/elastic_ip.rb
+++ b/src/cloud/ec2/lib/elastic_ip.rb
@@ -119,8 +119,7 @@ module ElasticIP
 
         user_id = retrieve_uid
         eip     = params["PublicIp"]
-        vmid    = params['InstanceId']
-        vmid    = vmid.split('-')[1] if vmid[0]==?i
+        vmid    = params['InstanceId'].sub(/^i\-0*/, '')
 
         unless vnet["TEMPLATE/EC2_ADDRESSES[IP=\"#{eip}\" and UID=\"#{retrieve_uid}\"]/IP"]
             rc = OpenNebula::Error.new("address:#{eip} does not exist")


### PR DESCRIPTION
The current code in `ElasticIP::associate_address()` strips the leading `i-` prefix of VM instance IDs, if found, in order to convert EC2 instance IDs into OpenNebula VM IDs. Unfortunately that does not work for IDs greater than 7, since the stripped string is interpreted as an octal number due to the remaining leading 0's:

```
$ econe-allocate-address
$ econe-describe-addresses 
  publicIp                instanceId
192.168.1.
$ econe-associate-address 192.168.1.1 i-00000106
$ econe-describe-addresses 
  publicIp                instanceId
192.168.1.                i-00000070 
```

(Note that decimal 106 is octal 70)
